### PR TITLE
Fix prop declaration in the FileSelect component.

### DIFF
--- a/src/Components/Misc/FileSelect.vue
+++ b/src/Components/Misc/FileSelect.vue
@@ -31,7 +31,7 @@
          *
          * Example: $api.files
          */
-        @Prop({type: Object, default: null}) getEndpoint: any;
+        @Prop({ type: Object, required: true }) getEndpoint: any;
 
         selected: Array<any> = [];
 


### PR DESCRIPTION
We use the `getEndpoint` prop like:

```
            return this.getEndpoint
                .setParameters(parameters)
                .get();
```

So it can't be null, but has to be required instead.