### PR TITLE
Add the `flat` and `tile` properties to the CardMain component.

### DIFF
--- a/src/Components/Cards/Main.vue
+++ b/src/Components/Cards/Main.vue
@@ -39,6 +39,11 @@
         @Prop({ type: Boolean, default: false }) flat: boolean;
 
         /**
+         * Removes the component's border-radius.
+         */
+        @Prop({ type: Boolean, default: false }) tile: boolean;
+
+        /**
          * Card title.
          */
         @Prop({ type: String, default: '' }) title: string;

--- a/src/Components/Cards/Main.vue
+++ b/src/Components/Cards/Main.vue
@@ -34,6 +34,11 @@
         @Prop({ type: Boolean, default: false }) outlined: boolean;
 
         /**
+         * Removes the card's elevation.
+         */
+        @Prop({ type: Boolean, default: false }) flat: boolean;
+
+        /**
          * Card title.
          */
         @Prop({ type: String, default: '' }) title: string;


### PR DESCRIPTION
There was the `flat` property for the `v-card` component introduced which removes the card's elevation and also removes a border. Useful when you want to put one card inside another and with elevation and border they look ugly. Or if you want to arrange things together in one (logical) card element but don't want to actually render a card. And in other cases when a default card style doesn't play well with your custom styling and so on.